### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Cute Grids
 
-##About
+## About
 
 Cute Grids is a responsive grid system full of features to help designers and developers get started with their responsive layout. Visit [Cute Grids](http://www.cutegrids.com) for more details.
 
-##Features
+## Features
 
 * 12 Columns
 
@@ -20,12 +20,12 @@ Cute Grids is a responsive grid system full of features to help designers and de
 
 * plus more
 
-##Browser Support
+## Browser Support
 
 Works on Chrome, Safari, Firefox, Opera, IE9+.
 If you need Cute grids to work in IE8 then this is possible with using respond.js polyfill for Media queries and REM-unit-polyfill for rem untis .
 
-##Getting Started
+## Getting Started
 
 **Link to your stylesheet**
 
@@ -53,7 +53,7 @@ Wrap the cute columns in a row. Make sure that all cute columns add up to 12. Co
 
 For full instructions using Cute Grids visit [www.cutegrids.com](http://www.cutegrids.com)
 
-##Support
+## Support
 
 If you have any questions or need some support using Cute Grids then please feel free to contact me.
 
@@ -61,7 +61,7 @@ Email: [contact@dazzyweb.com](mailto:contact@dazzyweb.com)
 
 or connect with me on twitter [@dazzy_web](https://twitter.com/dazzy_web)
 
-##Copyright & License
+## Copyright & License
 
 Copyright (C) 2014 Darren Newberry - Released under the MIT License.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
